### PR TITLE
Fix bug where orders placed on static schedule have invalid date

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "SimpleSubs",
     "description": "Order sandwiches easily up to two weeks in advance using this app",
     "slug": "simple-subs",
-    "version": "4.1.1",
+    "version": "4.1.2",
     "platforms": [
       "ios",
       "android",
@@ -40,7 +40,7 @@
     },
     "android": {
       "package": "org.lwhs.simplesubs",
-      "versionCode": 15,
+      "versionCode": 16,
       "userInterfaceStyle": "automatic",
       "playStoreUrl": "https://play.google.com/store/apps/details?id=org.lwhs.simplesubs",
       "permissions": []

--- a/components/orders/OrderInputsList.js
+++ b/components/orders/OrderInputsList.js
@@ -431,15 +431,17 @@ const OrderInputsList = ({ title, focusedData, orderOptions, cancel, createNew, 
       return;
     }
     let newState;
+
     if (state.preset) {
       // Fills state with preset fields
       let presetKey = Object.keys(orderPresets).filter((id) => orderPresets[id].title === state.preset);
-      newState = { ...orderPresets[presetKey], date: state.date };
+      newState = {...orderPresets[presetKey], date: state.date};
     } else {
       // Filter out possible "empty" order dates (such as if a date did not have any possible options)
-      const stateKeysWithContent = Object.keys(state).filter((key) =>
-        key !== "date" && Object.keys(state[key]).length > 0
-      );
+      let stateKeysWithContent = Object.keys(state).filter((key) => Object.keys(state[key]).length > 0);
+      if (hasDynamicSchedule) {
+        stateKeysWithContent = stateKeysWithContent.filter((key) => key !== "date");
+      }
       let stateWithContent = {}
       stateKeysWithContent.forEach((key) => stateWithContent[key] = state[key]);
       newState = resetPickerVals(stateWithContent, dynamicOptions);


### PR DESCRIPTION
Add conditional for dynamic schedule when cleaning up state to push
so that static schedule does not filter out date field.

Resolves: #54